### PR TITLE
chore: Bump PyArrow to version we've been testing with.

### DIFF
--- a/flightsql/__init__.py
+++ b/flightsql/__init__.py
@@ -13,7 +13,7 @@ from flightsql.exceptions import (
     Warning,
 )
 
-__version__ = "0.1.1"
+__version__ = "0.2.0"
 
 __all__ = [
     "connect",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "flightsql-dbapi"
-version = "0.1.1"
+version = "0.2.0"
 authors = [
   { name="Brett Buddin", email="brett@buddin.org" },
 ]
@@ -18,7 +18,7 @@ classifiers = [
 ]
 dependencies = [
     "sqlalchemy<2.0",
-    "pyarrow>=5.0.0",
+    "pyarrow>=10.0.0",
     "protobuf>=4.21.0"
 ]
 


### PR DESCRIPTION
There's a known gRPC issue w.r.t. CA certs hiding out in versions < 10 that we want users to avoid. We've been using 10 during the process of developing this package so 5 was way too low anyway.