### PR TITLE
fix(dbapi): Don't close Cursors if they are already closed.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,6 @@ jobs:
       - name: Lint
         run: make lint
       - name: Start Reference Server
-        run: docker compose -f ./.github/docker-compose.yml up --detach
+        run: docker compose -f ./docker-compose.yml up --detach
       - name: Test
         run: make test INTEGRATION=1

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @brettbuddin
+* @helenosheaa

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.3'
 services:
   sqlite-flightsql-server:
-    build: ../contrib/sqlite-flightsql-server
+    build: ./contrib/sqlite-flightsql-server
     ports:
       - '3000:3000'
     restart: always

--- a/flightsql/__init__.py
+++ b/flightsql/__init__.py
@@ -13,7 +13,7 @@ from flightsql.exceptions import (
     Warning,
 )
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 __all__ = [
     "connect",

--- a/flightsql/dbapi.py
+++ b/flightsql/dbapi.py
@@ -141,7 +141,8 @@ class Connection:
     def close(self) -> None:
         self.closed = True
         for cursor in self.cursors:
-            cursor.close()
+            if not cursor.closed:
+                cursor.close()
 
     @check_closed
     def cursor(self) -> Cursor:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "flightsql-dbapi"
-version = "0.2.0"
+version = "0.2.1"
 authors = [
   { name="Brett Buddin", email="brett@buddin.org" },
 ]

--- a/tests/test_dbapi.py
+++ b/tests/test_dbapi.py
@@ -76,5 +76,5 @@ def test_resolve_sql_type():
         (pa.bool_(), sqltypes.BOOLEAN),
         (pa.binary(), sqltypes.BINARY),
     ]
-    for (actual, expected) in cases:
+    for actual, expected in cases:
         assert resolve_sql_type(actual) == expected


### PR DESCRIPTION
Closure of the parent `Connection` closes all child `Cursors`, but if the `Cursor` is already closed we get an exception in Superset. This happens consistently in the Database Connection settings page. Thanks for reporting it @jdstrand.

We've also moved the `docker-compose.yml` file over to the root of the project to ease spinning up a sample server to run with `make test INTEGRATION=1`.