### PR TITLE
feat: allow flight client passthru args

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
-:warning: This library is experimental and under active development. The APIs it
-provides could change at any time so use at your own risk.
+:warning: This library is experimental.  Further development may be spotty since
+[influxdb3-python](https://github.com/InfluxCommunity/influxdb3-python) module is the
+[recommended Python API](https://docs.influxdata.com/influxdb/cloud-serverless/reference/client-libraries/v3/python/).
+
+The APIs provided here may change and functionality may not be maintained.  Use at your own risk.
 
 ## Overview
 

--- a/flightsql/__init__.py
+++ b/flightsql/__init__.py
@@ -13,7 +13,7 @@ from flightsql.exceptions import (
     Warning,
 )
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 __all__ = [
     "connect",

--- a/flightsql/client.py
+++ b/flightsql/client.py
@@ -336,7 +336,7 @@ def create_flight_client(
     if insecure:
         protocol = "tcp"
     elif disable_server_verification:
-        client_args["disable_server_verification"] = True
+        flight_client_kwargs["disable_server_verification"] = True
 
     url = f"grpc+{protocol}://{host}:{port}"
     client = flight.FlightClient(url, **flight_client_kwargs)

--- a/flightsql/client.py
+++ b/flightsql/client.py
@@ -104,6 +104,12 @@ class FlightSQLClient:
     """
 
     def __init__(self, *args, features: Optional[Dict[str, str]] = None, **kwargs):
+        """Initializes the client with the following parameters (see create_flight_client()):
+
+        host, port, user, password, token, insecure, disable_server_verification, metadata, features
+
+        Additional keyword arguments are passed on as keyword arguments to flight.FlightClient
+        """
         client, headers = create_flight_client(*args, **kwargs)
         self.client = client
         self.headers = headers
@@ -324,17 +330,16 @@ def create_flight_client(
     insecure: Optional[bool] = None,
     disable_server_verification: Optional[bool] = None,
     metadata: Optional[Dict[str, str]] = None,
-    **kwargs: Any,
+    **flight_client_kwargs: Any,
 ) -> Tuple[flight.FlightClient, List[Tuple[bytes, bytes]]]:
     protocol = "tls"
-    client_args = {}
     if insecure:
         protocol = "tcp"
     elif disable_server_verification:
         client_args["disable_server_verification"] = True
 
     url = f"grpc+{protocol}://{host}:{port}"
-    client = flight.FlightClient(url, **client_args)
+    client = flight.FlightClient(url, **flight_client_kwargs)
 
     headers = []
     if user or password:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "flightsql-dbapi"
-version = "0.2.1"
+version = "0.2.2"
 authors = [
   { name="Brett Buddin", email="brett@buddin.org" },
 ]
@@ -24,15 +24,15 @@ dependencies = [
 
 [project.optional-dependencies]
 test = [
-    "pandas",
+    "pandas>2.0",
     "pytest",
     "pytest-cov[all]"
 ]
 lint = [
     "black",
     "flake8",
-    "isort",
-    "mypy",
+    "isort>5.10.0",
+    "mypy>1.5.0",
     "pyproject-flake8",
     "toml-cli",
     "types-protobuf",


### PR DESCRIPTION
This change allows the caller to pass arguments through to the underlying flight library when creating a client.  I am bumping the version number to mark when this feature is added.

Additionally, to get this to build on my Ubuntu 23.04 host, I needed to add some version qualifiers to the dependencies which also speeds up the process as well.

Lastly, this repo looks dead, so I've updated the warning in the README to steer towards the recommended client library. I don't want my update to convey freshness or activity that may be unlikely in the future. I'm not certain this particular interface
has no continuing value, however, so I left the wording pretty vague and non-committal. There may be additional context I'm missing.

I ran make test:
```
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.11.4, pytest-7.4.2, pluggy-1.3.0
rootdir: /home/reidk/flightsql-dbapi
plugins: cov-4.1.0
collected 14 items                                                                                                                                                                                                

tests/test_dbapi.py ....
tests/test_integration_dbapi.py sssssss
tests/test_integration_sqlalchemy.py sss

---------- coverage: platform linux, python 3.11.4-final-0 -----------
Name                      Stmts   Miss  Cover
---------------------------------------------
flightsql/__init__.py         5      0   100%
flightsql/client.py         161    104    35%
flightsql/dbapi.py          233    102    56%
flightsql/exceptions.py      20      0   100%
flightsql/sqlalchemy.py      94     44    53%
flightsql/util.py             7      3    57%
---------------------------------------------
TOTAL                       520    253    51%


========================================================================================== 4 passed, 10 skipped in 0.41s ==========================================================================================
```