### PR TITLE
chore: update pyarrow minimum to 14.0.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 ]
 dependencies = [
     "sqlalchemy<2.0",
-    "pyarrow>=10.0.0",
+    "pyarrow>=14.0.1",
     "protobuf>=4.21.0"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 description = "DB API 2 and SQLAlchemy adapter for Flight SQL"
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
References:
- Closes: https://github.com/influxdata/idpe/issues/18360
- https://arrow.apache.org/blog/2023/11/09/14.0.1-release/

Note, `pyarrow` 13.0.0 requires python3.8 so I updated the github tests and pyproject.toml to use 3.8 and higher. This happened to allow the CI tests to pass, which they haven't for a while (3.7 was causing other problems before this PR).