### PR TITLE
rename has_table() params

### DIFF
--- a/flightsql/sqlalchemy.py
+++ b/flightsql/sqlalchemy.py
@@ -95,8 +95,8 @@ class FlightSQLDialect(default.DefaultDialect):
         return connection.connection.flightsql_get_schema_names()
 
     @reflection.cache
-    def has_table(self, connection, table, schema=None, **kwargs):
-        return table in self.get_table_names(connection, schema)
+    def has_table(self, connection, table_name, schema=None, **kwargs):
+        return table_name in self.get_table_names(connection, schema)
 
     def get_indexes(self, connection, table_name, schema, **kwargs):
         return []


### PR DESCRIPTION
Fix non-standard naming in order to solve the bug of failed downstream calls

https://github.com/pinterest/querybook/blob/e2efe8e2764759854f158a2703c6d3f8932bdb4a/querybook/server/lib/metastore/loaders/sqlalchemy_metastore_loader.py#L33

Hope it can be merged quickly and released.