### PR TITLE
fix: use hatchling 1.18

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling<=1.18.0"]  
 build-backend = "hatchling.build"
 
 [project]


### PR DESCRIPTION
there's an issue with [hatchling 1.19](https://github.com/pypa/hatch/issues/1113) which is making [all our builds](https://github.com/influxdata/flightsql-dbapi/actions/runs/7201435727/job/19617545885?pr=23) fail - force it to use 1.18 for now