### PR TITLE
fix: add the missing `options` argument for do_put

### DIFF
--- a/flightsql/client.py
+++ b/flightsql/client.py
@@ -76,7 +76,7 @@ class PreparedStatement:
         desc = flight_descriptor(cmd)
 
         if binding is not None and binding.num_rows > 0:
-            writer, reader = self.client.do_put(desc, binding.schema)
+            writer, reader = self.client.do_put(desc, binding.schema, self.options)
             writer.write(binding)
             writer.done_writing()
             reader.read()


### PR DESCRIPTION
The `options` argument is required by the server to do authorization.