### PR TITLE
chore: update readme guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 :warning: This library is experimental.  Further development may be spotty since
 [influxdb3-python](https://github.com/InfluxCommunity/influxdb3-python) module is the
 [recommended Python API](https://docs.influxdata.com/influxdb/cloud-serverless/reference/client-libraries/v3/python/).
+Note that this project should continue to work as a driver between an Influxdata database and third party platforms
+supporting DB API 2 and SQLAlchemy like Apache Superset.
 
 The APIs provided here may change and functionality may not be maintained.  Use at your own risk.
 


### PR DESCRIPTION
The folks supporting the client libraries said that there isn't a priority on updating influxdb3-python to adhere to Alchemy/DB API 2 and requested this change in response to some inquiries about supporting integration with Apache SuperSet.

This change notes that this library should continue to work in that capacity, but does not imply any level of support.